### PR TITLE
Update captcher.py

### DIFF
--- a/captcher/captcher.py
+++ b/captcher/captcher.py
@@ -352,9 +352,11 @@ class Captcher(Core):
                 if not result:  # Immediate kick
                     await self._kicker(user, "Failed the captcha. (Immediate kick)")
                     has_been_kicked = True
-            await asyncio.sleep(5)
+            
             if not captched and not has_been_kicked:
                 await self._kicker(user, "Failed the captcha.")
+                
+            await asyncio.sleep(5)
             await bot_message.delete()
             await user_message.delete()
             await final.delete()


### PR DESCRIPTION
Bot fails to delete "Failed the captcha." message when the user times out rather than typing and either failing or succeeding to pass the captcha.