### PR TITLE
Update core.py

### DIFF
--- a/captcher/core.py
+++ b/captcher/core.py
@@ -616,9 +616,19 @@ class Core(commands.Cog):
         await asyncio.sleep(5)
         if not has_been_kicked and not success:
             await self._kicker(member, "Failed the captcha.")
-        await bot_message.delete()
-        await user_message.delete()
-        await final.delete()
+        try:        
+            await bot_message.delete()
+        except: # catch *all* exceptions
+            pass
+        try:
+            await user_message.delete()
+        except: # catch *all* exceptions
+            pass
+        try:
+            await final.delete()
+        except: # catch *all* exceptions
+            pass
+        del self.in_challenge[member.id]
         del self.in_challenge[member.id]
 
     @commands.Cog.listener()


### PR DESCRIPTION
Fix for exceptions being thrown before all message are cleaned up. For example, if user joins and doesn't enter captcha, then bot would leave an orphaned "Failed Captcha" message. Turns out that sometimes bot_message and or user_message would be None. Put them in try blocks, so we could jump over those exceptions. May not want to catch ALL exceptions. I will check what exceptions it throws and only test for them, when i have some more time. This was implemented and tested on our 23K member server.