### PR TITLE
[Letters] Fix json key

### DIFF
--- a/letters/info.json
+++ b/letters/info.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/Cog-Creators/Red-DiscordBot/V3/develop/schema/red_cog.schema.json",
-    "authors": [
+    "author": [
         "Predeactor"
     ],
     "end_user_data_statement": "This cog store data about users persistently for saving datas. Red may store your discord ID with your data you set and receive.",


### PR DESCRIPTION
Seems like `authors` isn't part of the schema, and it should be `author`, correct me if I'm wrong. It managed to error out the index command anyway, lol